### PR TITLE
Remove resume from header + add Home and Tech links

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,6 @@
 </h1>
 
 ## Snapshot 📸
-<img width="963" alt="Screen Shot 2020-03-08 at 11 50 01 AM" src="https://user-images.githubusercontent.com/8409475/76166184-fc74e600-6132-11ea-9fb5-1dda46c9d42d.png">
+<img width="1017" alt="Screen Shot 2020-03-14 at 2 41 41 PM" src="https://user-images.githubusercontent.com/8409475/76688486-9c36e600-6603-11ea-91d3-3a4ffdb32f9c.png">
 
-<img width="1121" alt="Screen Shot 2020-03-08 at 11 35 49 AM" src="https://user-images.githubusercontent.com/8409475/76165893-03025e00-6131-11ea-96cb-fd7739ea12a2.png">
-
-![Mar-08-2020 11-39-21](https://user-images.githubusercontent.com/8409475/76165980-98055700-6131-11ea-941f-b9ff6c9dd472.gif)
+<img width="1056" alt="Screen Shot 2020-03-14 at 3 00 25 PM" src="https://user-images.githubusercontent.com/8409475/76688586-91c91c00-6604-11ea-9dbd-f08ff53a248e.png">

--- a/src/components/Header/HeaderTitleItems.jsx
+++ b/src/components/Header/HeaderTitleItems.jsx
@@ -5,24 +5,31 @@ import copy from '../../utils/copy';
 import PropTypes from "prop-types";
 
 const {
+    homeLinkTitle,
+    homeLink,
+    techLinkTitle,
+    techLink,
     projectsLinkTitle,
     projectsLink,
-    resumeLinkTitle,
-    resumeLink,
     contactLinkTitle,
     contactLink
 } = copy.HeaderTitleItems;
 
 const headerTitles = [
     {
+        id: "home",
+        title: homeLinkTitle,
+        link: homeLink,
+    },
+    {
+        id: "tech",
+        title: techLinkTitle,
+        link: techLink,
+    },
+    {
         id: "projects",
         title: projectsLinkTitle,
         link: projectsLink,
-    },
-    {
-        id: "resume",
-        title: resumeLinkTitle,
-        link: resumeLink,
     },
     {
         id: "contact",

--- a/src/utils/copy.js
+++ b/src/utils/copy.js
@@ -15,10 +15,12 @@ const copy = {
         emailIconLink: "mailto: brit.smith7@gmail.com"
     },
     HeaderTitleItems: {
+        homeLinkTitle: "Home",
+        homeLink: "#",
+        techLinkTitle: "Tech",
+        techLink: "#tech",
         projectsLinkTitle: "Projects",
         projectsLink: "#projects",
-        resumeLinkTitle: "Resume",
-        resumeLink: "#resume",
         contactLinkTitle: "Contact Me",
         contactLink: "#contact",
     },


### PR DESCRIPTION
## What does this PR do :question:
This PR removes the explicit "Resume" link button from the header. I also added a "Home" button that will scroll to the top, and a "Tech" button that will scroll to a list of favorite technologies to work with.


## Any packages added :package:
N/A


## How to test it :microscope:
1. Checkout this branch
1. Run `npm i` to install tooling
1. Run `gatsby develop`.
1. Navigate to `http://localhost:8000`
1. Confirm that the header no longer contains a "Resume" button, and now has a "Home" and "Tech" section (see screenshots below)


## Any background info you would like to include :white_check_mark:
N/A


## Screenshots (if applicable) 📸 
<img width="1143" alt="Screen Shot 2020-03-14 at 2 41 09 PM" src="https://user-images.githubusercontent.com/8409475/76688488-9d681300-6603-11ea-83b2-ae8013e2c6bc.png">

<img width="850" alt="Screen Shot 2020-03-14 at 2 42 00 PM" src="https://user-images.githubusercontent.com/8409475/76688484-9b9e4f80-6603-11ea-9f4d-f11ee51f9f6b.png">


