### PR TITLE
Projects section style refactor + updated heading hierarchy for accessibility

### DIFF
--- a/src/assets/css/project-section.css
+++ b/src/assets/css/project-section.css
@@ -15,6 +15,7 @@
 .project-card-name {
     font-size: .875rem;
     font-weight: 500;
+    letter-spacing: 0.275rem;
 }
 
 .project-card-tech {

--- a/src/assets/css/project-section.css
+++ b/src/assets/css/project-section.css
@@ -12,7 +12,14 @@
 }
 
 /* Headings */
-.project-card-heading {
+.project-card-name {
+    font-size: .875rem;
+    font-weight: 500;
+}
+
+.project-card-tech {
+    font-size: 1rem;
+    line-height: 1.1;
     color: var(--darkPurple);
 }
 

--- a/src/assets/jss/material-kit-react/components/cardHeaderStyle.jsx
+++ b/src/assets/jss/material-kit-react/components/cardHeaderStyle.jsx
@@ -7,7 +7,8 @@ import {
 } from "../../material-kit-react";
 const cardHeaderStyle = {
   cardHeader: {
-    fontWeight: "500",
+    fontSize: ".875rem",
+    fontWeight: "400",
     letterSpacing: "0.275rem",
     borderRadius: "3px",
     padding: "1rem 15px",

--- a/src/assets/jss/material-kit-react/components/cardHeaderStyle.jsx
+++ b/src/assets/jss/material-kit-react/components/cardHeaderStyle.jsx
@@ -7,9 +7,6 @@ import {
 } from "../../material-kit-react";
 const cardHeaderStyle = {
   cardHeader: {
-    fontSize: ".875rem",
-    fontWeight: "400",
-    letterSpacing: "0.275rem",
     borderRadius: "3px",
     padding: "1rem 15px",
     marginLeft: "15px",

--- a/src/components/Projects/CustomProjectCard.jsx
+++ b/src/components/Projects/CustomProjectCard.jsx
@@ -26,9 +26,11 @@ const CustomProjectCard = ({ project }) => {
     return(
         <>
             <Card>
-            <CardHeader color="primary">{title}</CardHeader>
+            <CardHeader color="primary">
+                <h4 className="project-card-name">{title}</h4>
+            </CardHeader>
             <CardBody>
-                <h4 className="project-card-heading">{techStack}</h4>
+                <h5 className="project-card-tech">{techStack}</h5>
                 <p className="project-card-body">{description}</p>
                 <div className="container-flex">
                     <CustomIconLinkGroup


### PR DESCRIPTION
## What does this PR do :question:
This PR corrects the heading hierarchy for the Project section, to make the page more compliant with accessibility standards. Since the headings in the rest of the page already cover `h1`, `h2`, and `h3`, the project title is now an `h4` and the tech stack list is now `h5`.

They styles had to be updated, since the default `h4` and `h5` styles were being applied.


## Any packages added :package:
N/A


## How to test it :microscope:
1. Checkout this branch
1. Run `npm i` to install tooling
1. Run `gatsby develop`.
1. Navigate to `http://localhost:8000`
1. **Expected:** Confirm that the project name heading and the heading used for the tech stack list matches the screenshot.
1. **Expected:** Using the browser's dev tools, confirm that, starting from the main title and ending with the project card's tech stack list, the page's heading hierarchy follows `h1` through `h5`. They should follow the heading order without skipping any heading types.


## Any background info you would like to include :white_check_mark:
WCAG standards for heading order: https://www.w3.org/WAI/tutorials/page-structure/headings/


## Screenshots (if applicable) :camera:
<img width="1099" alt="Screen Shot 2020-03-14 at 4 45 24 PM" src="https://user-images.githubusercontent.com/8409475/76690386-d14c3400-6615-11ea-86a6-be0487ef6e53.png">
<img width="1413" alt="Screen Shot 2020-03-14 at 5 05 30 PM" src="https://user-images.githubusercontent.com/8409475/76690414-09537700-6616-11ea-8191-61a31ace2f1e.png">
